### PR TITLE
Add a Black Diamond for AST-level Inlining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 .metadata
-build
+/build
 codacy-coverage.json
-graal
+/graal
 jacoco.exec
 jacoco.xml
-libs
+/libs
 mx
-src_gen
+/src_gen
+/docs

--- a/.settings/BD-Tests.launch
+++ b/.settings/BD-Tests.launch
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/BlackDiamonds/tests"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="2"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+<listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
+<listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=BlackDiamonds/tests"/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="BlackDiamonds"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
+</launchConfiguration>

--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ The benefit of this optimization is to improve interpreter performance, reduce
 compilation time, and possibly simplify interpreter debugging since it simplifies
 execution drastically.
 
+#### 4. Inlining/Splitting: Support parse-time inlining and run-time splitting
+
+The `inlining` diamond provides infrastructure to support inlining at parse time
+and splitting at execution time. Inlining enables us to optimize more complex
+structures such as loops, iteration, selection, or other elements that often
+take lambdas, closures, or other kind of anonymous methods. If they are provided
+lexically, and are trivially non-accessible by language constructs, it can be
+very beneficial to inline them on the AST level already to optimize execution
+time in the interpreter, which can also reduce compilation time.
+
+This infrastructure provides the basic mechanisms that a language independent.
+This includes a general visitor that can adapt lexical scopes for instance also
+after simple splitting, which can be necessary, for instance to ensure that
+the split methods are independent and specialize independently at run time.
+
 
 License and Acknowledgements
 ----------------------------

--- a/build.xml
+++ b/build.xml
@@ -236,5 +236,31 @@
             <arg line="-l Java -r jacoco.xml" />
         </java>
     </target>
+    
+    <target name="docs">
+      <javadoc 
+          destdir="docs" author="true" version="true" use="true"
+          windowtitle="Black Diamonds JavaDoc"
+          sourcepath="src"
+          packagenames="bd.*"
+          defaultexcludes="yes"
+          excludepackagenames="com.oracle.*"
+          public="true"
+          classpathref="project.classpath">
+
+        <!-- <fileset dir="src" defaultexcludes="yes">
+          <include name="src/**"/> -->
+          <!-- <exclude name="com/dummy/test/doc-files/**"/> -->
+        <!-- </fileset> -->
+
+      <!-- <doctitle><![CDATA[<h1>Test</h1>]]></doctitle>
+      <bottom><![CDATA[<i>Copyright &#169; 2000 Dummy Corp. All Rights Reserved.</i>]]></bottom>
+      <tag name="todo" scope="all" description="To do:"/>
+      <group title="Group 1 Packages" packages="com.dummy.test.a*"/>
+      <group title="Group 2 Packages" packages="com.dummy.test.b*:com.dummy.test.c*"/>
+      <link offline="true" href="http://docs.oracle.com/javase/7/docs/api/" packagelistLoc="C:\tmp"/>
+      <link href="http://docs.oracle.com/javase/7/docs/api/"/> -->
+      </javadoc>
+    </target>
 
 </project>

--- a/build.xml
+++ b/build.xml
@@ -18,8 +18,8 @@
 
     <property name="mx.cmd" value="${basedir}/mx/mx" />
 
-    <property name="build.dir"   value="build"/>
-    <property name="classes.dir" value="${build.dir}/classes"/>
+    <property name="build.dir"   location="build"/>
+    <property name="classes.dir" location="${build.dir}/classes"/>
 
     <path id="project.classpath">
         <pathelement location="${classes.dir}" />

--- a/src/bd/basic/IdProvider.java
+++ b/src/bd/basic/IdProvider.java
@@ -13,6 +13,9 @@ public interface IdProvider<Id> {
   /**
    * Gets a Java string and needs to return an identifier. Typically, this is some form of
    * symbol or interned string that can be safely compared with reference equality.
+   *
+   * @param id the string version of the id
+   * @return the unique identifier
    */
   Id getId(String id);
 }

--- a/src/bd/inlining/InlinableNodes.java
+++ b/src/bd/inlining/InlinableNodes.java
@@ -1,0 +1,158 @@
+package bd.inlining;
+
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.List;
+
+import com.oracle.truffle.api.dsl.NodeFactory;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.SourceSection;
+
+import bd.basic.IdProvider;
+import bd.basic.ProgramDefinitionError;
+import bd.inlining.Inliner.FactoryInliner;
+import bd.settings.VmSettings;
+
+
+/**
+ * Represents the entry point to access the inlining functionality controlled with
+ * the @{@link Inline} annotation.
+ *
+ * <p>A typical use case would be in a parser, which can use the
+ * {@link #inline(Object, List, ScopeBuilder, SourceSection)} to request inlining.
+ * For this purpose, {@link InlinableNodes} takes a list of node classes and factories as
+ * candidates for inlining.
+ *
+ * @param <Id> the type of the identifiers used for mapping to primitives, typically some form
+ *          of interned string construct (see {@link IdProvider})
+ */
+public final class InlinableNodes<Id> {
+
+  /** The id provider is used to map strings in the {@link Inline} annotation to ids. */
+  private final IdProvider<Id> ids;
+
+  /** Inlinable nodes for selector. */
+  private final HashMap<Id, Inliner> inlinableNodes;
+
+  /**
+   * Initialize this registry for inlinable nodes.
+   *
+   * @param ids an id provider to convert strings to identifiers
+   * @param inlinableNodes list of {@link Node} classes that have the @{@link Inline}
+   *          annotation
+   * @param inlinableFactories list of {@link NodeFactory}s for classes that have
+   *          the @{@link Inline} annotation
+   */
+  public InlinableNodes(final IdProvider<Id> ids,
+      final List<Class<? extends Node>> inlinableNodes,
+      final List<NodeFactory<? extends Node>> inlinableFactories) {
+    this.ids = ids;
+    this.inlinableNodes = new HashMap<>();
+    initializeNodes(inlinableNodes);
+    initializeFactories(inlinableFactories);
+  }
+
+  private void initializeNodes(final List<Class<? extends Node>> inlinableNodes) {
+    if (inlinableNodes == null) {
+      return;
+    }
+
+    for (Class<? extends Node> nodeClass : inlinableNodes) {
+      Inline[] ann = getInlineAnnotation(nodeClass);
+      assert ann != null;
+
+      Constructor<?>[] ctors = nodeClass.getConstructors();
+      assert ctors.length == 1 : "We expect nodes marked with Inline to have only one constructor,"
+          + " or be used via node factories.";
+
+      for (Inline inAn : ann) {
+        assert !"".equals(inAn.selector());
+        Id selector = ids.getId(inAn.selector());
+        assert !this.inlinableNodes.containsKey(selector);
+
+        @SuppressWarnings("unchecked")
+        Inliner inliner = new Inliner(inAn, (Constructor<? extends Node>) ctors[0]);
+
+        this.inlinableNodes.put(selector, inliner);
+      }
+    }
+  }
+
+  private void initializeFactories(
+      final List<NodeFactory<? extends Node>> inlinableFactories) {
+    if (inlinableFactories == null) {
+      return;
+    }
+
+    for (NodeFactory<? extends Node> fact : inlinableFactories) {
+      Inline[] ann = getInlineAnnotation(fact);
+      assert ann != null;
+
+      for (Inline inAn : ann) {
+        assert !"".equals(inAn.selector());
+        Id selector = ids.getId(inAn.selector());
+
+        assert !this.inlinableNodes.containsKey(selector);
+        Inliner inliner = new FactoryInliner(inAn, fact);
+        this.inlinableNodes.put(selector, inliner);
+      }
+    }
+  }
+
+  /**
+   * Try to construct an inlined version for a potential node (which is not given here, but
+   * would be constructed as a fall-back version).
+   *
+   * <p>The potential node is identified with a {@code selector} and it is determined whether
+   * inlining is applicable by using the data from {@link Inline} and matching it with the
+   * {@code argNodes}.
+   *
+   * @param <N> the node type of the return value
+   * @param <S> the type of the {@link ScopeBuilder}
+   *
+   * @param selector to identify a potential inline replacement
+   * @param argNodes the argument/child nodes to the potential node
+   * @param builder used for providing context to the inlining operation
+   * @param source the source section of the potential node
+   * @return the inlined version of the potential node, or {@code null}, if inlining is not
+   *         applicable
+   * @throws ProgramDefinitionError in case the inlining would result in a structural violation
+   *           of program definition constraints. The error is language specific and not
+   *           triggered by the inlining logic.
+   */
+  public <N extends Node, S extends ScopeBuilder<S>> N inline(final Id selector,
+      final List<N> argNodes, final S builder, final SourceSection source)
+      throws ProgramDefinitionError {
+    Inliner inliner = inlinableNodes.get(selector);
+    if (inliner == null || (VmSettings.DYNAMIC_METRICS && inliner.isDisabled())) {
+      return null;
+    }
+
+    if (!inliner.matches(argNodes)) {
+      return null;
+    }
+
+    return inliner.create(argNodes, builder, source);
+  }
+
+  /**
+   * Get the {@link Inline} annotation from a {@link NodeFactory}.
+   */
+  private <T extends Node> Inline[] getInlineAnnotation(final NodeFactory<T> factory) {
+    Class<?> nodeClass = factory.getNodeClass();
+    return nodeClass.getAnnotationsByType(Inline.class);
+  }
+
+  /**
+   * Get the {@link Inline} annotation from a {@link Node} class.
+   */
+  private Inline[] getInlineAnnotation(final Class<? extends Node> nodeClass) {
+    Inline[] annotations = nodeClass.getAnnotationsByType(Inline.class);
+    if (annotations == null || annotations.length < 1) {
+      throw new IllegalArgumentException("The class " + nodeClass.getName()
+          + " was registered with InlinableNodes, but was not marked with @Inline."
+          + " Please make sure it has the right annotation.");
+    }
+    return annotations;
+  }
+}

--- a/src/bd/inlining/Inline.java
+++ b/src/bd/inlining/Inline.java
@@ -1,0 +1,71 @@
+package bd.inlining;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Annotation that marks nodes as inlined versions for language constructs.
+ * More complex nodes/constructs are to be replaced by these nodes in the parser.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+@Repeatable(Inline.Container.class)
+public @interface Inline {
+
+  /**
+   * Selector, i.e., identifier for a node to determine that inlining applies.
+   *
+   * @return a string identifying the node
+   */
+  String selector();
+
+  /**
+   * The arguments, by index, which need to be inlinable to make this node applicable.
+   *
+   * @return indexes of the inlinable argument nodes
+   */
+  int[] inlineableArgIdx();
+
+  /**
+   * The argument nodes might need extra temporary variables when being inlined.
+   *
+   * @return indexes of the argument nodes that need a temporary variable
+   */
+  int[] introduceTemps() default {};
+
+  /**
+   * Additional values to be provided as arguments to the node constructor.
+   *
+   * @return array value identifies, currently either {@link True} or {@link False}
+   */
+  Class<?>[] additionalArgs() default {};
+
+  /**
+   * Disabled for Dynamic Metrics.
+   *
+   * @return true if inlining should not be applied, false otherwise
+   */
+  boolean disabled() default false;
+
+  /**
+   * Represents a true value for an additional argument.
+   * Can be used for {@link #additionalArgs()}.
+   */
+  class True {}
+
+  /**
+   * Represents a false value for an additional argument.
+   * Can be used for {@link #additionalArgs()}.
+   */
+  class False {}
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE})
+  @interface Container {
+    Inline[] value();
+  }
+}

--- a/src/bd/inlining/Inliner.java
+++ b/src/bd/inlining/Inliner.java
@@ -1,0 +1,151 @@
+package bd.inlining;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+import com.oracle.truffle.api.dsl.NodeFactory;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.SourceSection;
+
+import bd.basic.ProgramDefinitionError;
+import bd.inlining.Inline.False;
+import bd.inlining.Inline.True;
+import bd.inlining.nodes.Inlinable;
+import bd.inlining.nodes.WithSource;
+
+
+class Inliner {
+  protected final Inline inline;
+
+  private final Constructor<? extends Node> ctor;
+
+  Inliner(final Inline inline, final Constructor<? extends Node> ctor) {
+    this.inline = inline;
+    this.ctor = ctor;
+  }
+
+  public boolean isDisabled() {
+    return inline.disabled();
+  }
+
+  public boolean matches(final List<? extends Node> argNodes) {
+    int[] args = inline.inlineableArgIdx();
+    assert args != null;
+
+    boolean allInlinable = true;
+    for (int i : args) {
+      allInlinable &= argNodes.get(i) instanceof Inlinable;
+    }
+    return allInlinable;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public <N extends Node> N create(final List<N> argNodes, final ScopeBuilder scopeBuilder,
+      final SourceSection source) throws ProgramDefinitionError {
+    Object[] args = new Object[argNodes.size() + inline.inlineableArgIdx().length
+        + inline.additionalArgs().length];
+
+    assert args.length == ctor.getParameterCount();
+
+    int i = 0;
+    for (N arg : argNodes) {
+      args[i] = arg;
+      i += 1;
+    }
+
+    for (int a : inline.inlineableArgIdx()) {
+      args[i] = ((Inlinable) argNodes.get(a)).inline(scopeBuilder);
+      i += 1;
+    }
+
+    for (Class<?> c : inline.additionalArgs()) {
+      if (c == True.class) {
+        args[i] = true;
+      } else {
+        assert c == False.class;
+        args[i] = false;
+      }
+      i += 1;
+    }
+    try {
+      N node = (N) ctor.newInstance(args);
+      ((WithSource) node).initialize(source);
+      return node;
+    } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
+        | InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Nodes that use a factory are expected to be structured so that the first argNodes are
+   * going to be evaluated by the DSL, which means, they are going to be appended at the end
+   * of the args array.
+   *
+   * <p>The rest is treated as normal, first the args, then the inlined args,
+   * then possibly to be introduced temps, and finally possible additional args.
+   *
+   * @param <ExprT>
+   * @param <NodeState>
+   * @param <MethodT>
+   * @param <OuterT>
+   * @param <S>
+   * @param <SB>
+   */
+  static class FactoryInliner extends Inliner {
+    private final NodeFactory<? extends Node> factory;
+
+    FactoryInliner(final Inline inline, final NodeFactory<? extends Node> factory) {
+      super(inline, null);
+      this.factory = factory;
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public <N extends Node> N create(final List<N> argNodes, final ScopeBuilder scopeBuilder,
+        final SourceSection source) throws ProgramDefinitionError {
+      Object[] args = new Object[argNodes.size() + inline.inlineableArgIdx().length
+          + inline.introduceTemps().length + inline.additionalArgs().length];
+
+      assert args.length == factory.getNodeSignatures().get(0).size();
+
+      int restArgs = factory.getExecutionSignature().size();
+
+      int i = 0;
+      for (int j = 0; j < argNodes.size(); j += 1) {
+        if (j < restArgs) {
+          int endOffset = args.length - restArgs + j;
+          args[endOffset] = argNodes.get(j);
+        } else {
+          args[i] = argNodes.get(j);
+          i += 1;
+        }
+      }
+
+      for (int a : inline.inlineableArgIdx()) {
+        args[i] = ((Inlinable) argNodes.get(a)).inline(scopeBuilder);
+        i += 1;
+      }
+
+      for (int a : inline.introduceTemps()) {
+        args[i] = scopeBuilder.introduceTempForInlinedVersion(
+            (Inlinable) argNodes.get(a), source);
+      }
+
+      for (Class<?> c : inline.additionalArgs()) {
+        if (c == True.class) {
+          args[i] = true;
+        } else {
+          assert c == False.class;
+          args[i] = false;
+        }
+        i += 1;
+      }
+
+      N node = (N) factory.createNode(args);
+      ((WithSource) node).initialize(source);
+      return node;
+    }
+  }
+}

--- a/src/bd/inlining/NodeState.java
+++ b/src/bd/inlining/NodeState.java
@@ -1,0 +1,14 @@
+package bd.inlining;
+
+/**
+ * This {@link NodeState} is used by the node factory methods of {@link Variable} to pass in
+ * required state.
+ * It is thus merely a marker interface.
+ *
+ * <p>Node state can typically include information about lexical bindings, for instance in form
+ * of unique identifiers, which might be class names or ids of mixins or similar lexical
+ * constructs.
+ */
+public interface NodeState {
+
+}

--- a/src/bd/inlining/NodeVisitorUtil.java
+++ b/src/bd/inlining/NodeVisitorUtil.java
@@ -1,0 +1,22 @@
+package bd.inlining;
+
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.NodeVisitor;
+
+import bd.basic.nodes.DummyParent;
+
+
+final class NodeVisitorUtil {
+
+  @SuppressWarnings("unchecked")
+  public static <ExprT extends Node> ExprT applyVisitor(final ExprT body,
+      final NodeVisitor visitor) {
+    DummyParent dummyParent = new DummyParent(body);
+
+    body.accept(visitor);
+
+    // need to return the child of the dummy parent,
+    // since it could have been replaced
+    return (ExprT) dummyParent.child;
+  }
+}

--- a/src/bd/inlining/Scope.java
+++ b/src/bd/inlining/Scope.java
@@ -1,0 +1,58 @@
+package bd.inlining;
+
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.RootNode;
+
+
+/**
+ * A {@link Scope} is meant to represent a lexical construct that delineate a set of
+ * {@link Variable} definitions that belong together, usually based on the textual/language
+ * properties of the implemented language.
+ *
+ * <p>Many languages use lexical scopes, i.e., grouping of variables based on textual elements.
+ * Often such groups are delimited by parentheses or other indicators for textual blocks.
+ *
+ * <p>Scopes are expected to form a chain from the inner to the outer scopes.
+ *
+ * @param <This> the concrete type of the scope
+ * @param <MethodT> the type for a run-time representation of a method, block, lambda,
+ *          typically at the implementation level, not necessarily exposed on the language
+ *          level. It is likely a subclass of {@link RootNode}.
+ */
+public interface Scope<This extends Scope<This, MethodT>, MethodT> {
+
+  /**
+   * The set of variables defined by this scope.
+   *
+   * <p>The set excludes variables that are defined in other scopes, even if they might be
+   * logically part of the set from language perspective, perhaps because of nesting scopes.
+   *
+   * @param <T> the type of the {@link Variable} implementation
+   *
+   * @return the set of variables defined in this scope
+   */
+  <T extends Variable<? extends Node>> T[] getVariables();
+
+  /**
+   * The scope directly enclosing the current scope.
+   *
+   * @return the outer scope, or {@code null} if it is already the final scope
+   */
+  This getOuterScopeOrNull();
+
+  /**
+   * Lookup the scope corresponding to the given run-time entity, which often corresponds to a
+   * nested method, block, lambda, etc.
+   *
+   * @param method, the method, block, lambda, etc, for which the scope is to be determined
+   * @return a scope, or {@code null}
+   */
+  This getScope(MethodT method);
+
+  /**
+   * A name identifying the scope, used for debugging.
+   *
+   * @return a human-readable name for debugging
+   */
+  String getName();
+}

--- a/src/bd/inlining/ScopeAdaptationVisitor.java
+++ b/src/bd/inlining/ScopeAdaptationVisitor.java
@@ -1,0 +1,244 @@
+package bd.inlining;
+
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.NodeUtil;
+import com.oracle.truffle.api.nodes.NodeVisitor;
+
+import bd.inlining.nodes.ScopeReference;
+
+
+/**
+ * A Truffle AST {@link NodeVisitor} that is used to fix up {@link ScopeReference} after any
+ * scope changes, for instance caused by inlining or splitting.
+ */
+public final class ScopeAdaptationVisitor implements NodeVisitor {
+
+  protected final Scope<?, ?> scope;
+
+  protected final boolean outerScopeChanged;
+
+  /**
+   * This visitor refers to the scope at the contextLevel given here, and thus, needs to apply
+   * its transformations to elements referring to that level.
+   */
+  public final int contextLevel;
+
+  /**
+   * Use the visitor to adapt a copy of the given {@code body} to the current scope.
+   *
+   * @param <N> the type of the returned node
+   *
+   * @param body an AST that needs to be adapted
+   * @param newScope is the scope the body needs to be adapted to
+   * @param appliesTo the context level, which needs to be changed
+   * @param someOuterScopeIsMerged a flag that can possibly used for optimization to decide
+   *          whether a node needs to be adapted
+   * @return a copy of {@code body} adapted to the given scope
+   */
+  public static <N extends Node> N adapt(final N body, final Scope<?, ?> newScope,
+      final int appliesTo, final boolean someOuterScopeIsMerged) {
+    N inlinedBody = NodeUtil.cloneNode(body);
+
+    return NodeVisitorUtil.applyVisitor(inlinedBody,
+        new ScopeAdaptationVisitor(newScope, appliesTo, someOuterScopeIsMerged));
+  }
+
+  private ScopeAdaptationVisitor(final Scope<?, ?> scope, final int appliesTo,
+      final boolean outerScopeChanged) {
+    if (scope == null) {
+      throw new IllegalArgumentException(
+          "InliningVisitor requires a scope, but got scope==null");
+    }
+    this.scope = scope;
+    this.contextLevel = appliesTo;
+    this.outerScopeChanged = outerScopeChanged;
+  }
+
+  /**
+   * @return true if some outer scope was changed, for instance merged with another one.
+   */
+  public boolean outerScopeChanged() {
+    return outerScopeChanged;
+  }
+
+  /**
+   * The result of a lookup in the scope chain to find a variable and its context level.
+   *
+   * @param <N> the type of node used for node access, can be very unprecise
+   */
+  public static final class ScopeElement<N extends Node> {
+
+    /** The variable found by the lookup. */
+    public final Variable<N> var;
+
+    /**
+     * The context level at which the variable is defined, relative to the start of the lookup.
+     */
+    public final int contextLevel;
+
+    private ScopeElement(final Variable<N> var, final int contextLevel) {
+      this.var = var;
+      this.contextLevel = contextLevel;
+    }
+
+    @Override
+    public String toString() {
+      return "ScopeElement[" + var.toString() + ", ctx: " + contextLevel + "]";
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <N extends Node> ScopeElement<N> getSplitVar(final Variable<N> var,
+      final Scope<?, ?> scope, final int lvl) {
+    for (Variable<? extends Node> v : scope.getVariables()) {
+      if (v.equals(var)) {
+        return new ScopeElement<>((Variable<N>) v, lvl);
+      }
+    }
+
+    Scope<?, ?> outer = scope.getOuterScopeOrNull();
+    if (outer == null) {
+      throw new IllegalStateException("Couldn't find var: " + var.toString());
+    } else {
+      return getSplitVar(var, outer, lvl + 1);
+    }
+  }
+
+  /**
+   * Get the variable adapted to the current scope.
+   *
+   * @param var in the un-adapted node
+   * @return the adapted version of the variable
+   */
+  public <N extends Node> ScopeElement<N> getAdaptedVar(final Variable<N> var) {
+    return getSplitVar(var, scope, 0);
+  }
+
+  /**
+   * Get the adapted scope for an embedded block, lambda, method etc.
+   *
+   * @param <S> the scope type
+   * @param <MethodT> the type of the run-time element representing the scope
+   *
+   * @param method, the run-time element for which to determine the adapted scope
+   *
+   * @return the adapted scope for the given method
+   */
+  @SuppressWarnings("unchecked")
+  public <S extends Scope<S, MethodT>, MethodT> S getScope(final MethodT method) {
+    return ((S) scope).getScope(method);
+  }
+
+  /**
+   * The current scope, which had been adapted before instantiating the visitor.
+   *
+   * @param <S> the scope type
+   * @param <MethodT> the type of the run-time element representing the scope
+   *
+   * @return the current scope
+   */
+  @SuppressWarnings("unchecked")
+  public <S extends Scope<S, MethodT>, MethodT> S getCurrentScope() {
+    return (S) scope;
+  }
+
+  /**
+   * Adapt the given node.
+   *
+   * @return true, if the process should continue
+   */
+  @Override
+  public boolean visit(final Node node) {
+    if (node instanceof ScopeReference) {
+      ((ScopeReference) node).replaceAfterScopeChange(this);
+    }
+    return true;
+  }
+
+  /**
+   * Factory method to update a read node with an appropriate version for the adapted scope.
+   *
+   * @param <N> the type of the node to be returned
+   *
+   * @param var the variable accessed by {@code node}
+   * @param node the read node
+   * @param ctxLevel the context level of the node
+   */
+  public <N extends Node> void updateRead(final Variable<?> var, final N node,
+      final int ctxLevel) {
+    ScopeElement<? extends Node> se = getAdaptedVar(var);
+    if (se.var != var || se.contextLevel < ctxLevel) {
+      node.replace(se.var.getReadNode(se.contextLevel, node.getSourceSection()));
+    } else {
+      assert ctxLevel == se.contextLevel;
+    }
+  }
+
+  /**
+   * Factory method to update a write node with an appropriate version for the adapted scope.
+   *
+   * @param <N> the type of the node to be returned
+   *
+   * @param var the variable accessed by {@code node}
+   * @param node the write node
+   * @param valExpr the expression that is evaluated to determine the value to be written to
+   *          the variable
+   * @param ctxLevel the context level of the node
+   */
+  public <N extends Node> void updateWrite(final Variable<N> var, final N node,
+      final N valExpr, final int ctxLevel) {
+    ScopeElement<N> se = getAdaptedVar(var);
+    if (se.var != var || se.contextLevel < ctxLevel) {
+      node.replace(se.var.getWriteNode(se.contextLevel, valExpr, node.getSourceSection()));
+    } else {
+      assert ctxLevel == se.contextLevel;
+    }
+  }
+
+  /**
+   * Factory method to update a <code>this</code>-read node with an appropriate version for the
+   * adapted scope.
+   *
+   * @param <N> the type of the node to be returned
+   *
+   * @param var the variable accessed by {@code node}
+   * @param node the {@code this} node
+   * @param state additional state needed to initialize the adapted node
+   * @param ctxLevel the context level of the node
+   */
+  public <N extends Node> void updateThisRead(final Variable<?> var, final N node,
+      final NodeState state, final int ctxLevel) {
+    ScopeElement<? extends Node> se = getAdaptedVar(var);
+    if (se.var != var || se.contextLevel < ctxLevel) {
+      node.replace(se.var.getThisReadNode(se.contextLevel, state, node.getSourceSection()));
+    } else {
+      assert ctxLevel == se.contextLevel;
+    }
+  }
+
+  /**
+   * Factory method to update a <code>super</code>-read node with an appropriate version for
+   * the adapted scope.
+   *
+   * @param <N> the type of the node to be returned
+   *
+   * @param var the variable accessed by {@code node}
+   * @param node the {@code super} node
+   * @param state additional state needed to initialize the adapted node
+   * @param ctxLevel the context level of the node
+   */
+  public <N extends Node> void updateSuperRead(final Variable<?> var, final N node,
+      final NodeState state, final int ctxLevel) {
+    ScopeElement<? extends Node> se = getAdaptedVar(var);
+    if (se.var != var || se.contextLevel < ctxLevel) {
+      node.replace(se.var.getSuperReadNode(se.contextLevel, state, node.getSourceSection()));
+    } else {
+      assert ctxLevel == se.contextLevel;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + "[" + scope.getName() + "]";
+  }
+}

--- a/src/bd/inlining/ScopeBuilder.java
+++ b/src/bd/inlining/ScopeBuilder.java
@@ -1,0 +1,36 @@
+package bd.inlining;
+
+import com.oracle.truffle.api.source.SourceSection;
+
+import bd.basic.ProgramDefinitionError;
+import bd.inlining.nodes.Inlinable;
+
+
+/**
+ * Builds a {@link Scope}, typically at source processing time (i.e., source compilation time,
+ * which in a Truffle system refers to the time when the Truffle AST is created for execution).
+ *
+ * <p>A candidate for a concrete scope builder could be for instance the class that creates
+ * methods or lambdas when parsing code.
+ *
+ * @param <This> the concrete type of the builder
+ */
+public interface ScopeBuilder<This extends ScopeBuilder<This>> {
+
+  /**
+   * Introduce a temporary variable for the inlined version of a node.
+   *
+   * <p>Some code elements require additional temporary variables when they are inlined.
+   * An example is the lambda-body for a counting loop, which needs a temporary variable to
+   * perform the counting and communicate it to the lambda.
+   *
+   * @param node the node using a variable that needs to be represented as a new temporary
+   * @param source the synthetic source location for the new variable definition
+   * @return the introduced variable representing the temporary
+   * @throws ProgramDefinitionError when there is a consistency problem caused by introducing
+   *           the variable. This is supposed to be used to indicate errors in the user
+   *           program.
+   */
+  Variable<?> introduceTempForInlinedVersion(Inlinable<This> node, SourceSection source)
+      throws ProgramDefinitionError;
+}

--- a/src/bd/inlining/Variable.java
+++ b/src/bd/inlining/Variable.java
@@ -1,0 +1,92 @@
+package bd.inlining;
+
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.SourceSection;
+
+
+/**
+ * A {@link Variable} represents a variable most often in the user code, or sometimes internal
+ * to the language implementation.
+ *
+ * <p>Generally, we expect variables to be read or written, but do not require an
+ * implementation the writing operation, since variables might be immutable and initialized
+ * otherwise.
+ *
+ * <p>Some special variables, such as <code>this</code> can require extra handling and can thus
+ * require the use of special nodes. We provide here factory methods for <code>this</code>-like
+ * variables as well as <code>super</code>-like reads.
+ *
+ * <p>Note that variable access are typically associated with a <code>contextLevel</code>. The
+ * precise semantics is specific to your language's use of {@link Scope}s. But generally, we
+ * assume that scopes are defined lexically, and a context level of 0 means the local scope,
+ * and every increment represents one step outwards in a scope chain.
+ *
+ * @param <N> the type of nodes expected to be returned for reading variables
+ */
+public interface Variable<N extends Node> {
+
+  /**
+   * Create a node to read the value of this variable.
+   *
+   * @param contextLevel references the scope in which the variable is defined,
+   *          relative to the scope in which the read is done
+   * @param source of the read operation
+   * @return a node to read this variable
+   */
+  N getReadNode(int contextLevel, SourceSection source);
+
+  /**
+   * Create a node to write to this variable.
+   *
+   * @param contextLevel references the scope in which the variable is defined,
+   *          relative to the scope in which the write is done
+   * @param valueExpr is the expression that needs to be evaluated to determine the value,
+   *          which is to be written to the variable
+   * @param source of the write operation
+   * @return a node to write this variable
+   */
+  default N getWriteNode(final int contextLevel, final N valueExpr,
+      final SourceSection source) {
+    throw new UnsupportedOperationException(
+        "Variable.getWriteNode not supported on this type of variable: "
+            + getClass().getSimpleName());
+  }
+
+  /**
+   * Create a node to read the special <code>this</code> variable.
+   *
+   * <p>This operation should only be used on variables that are <code>this</code>-like
+   * variables.
+   *
+   * @param contextLevel references the scope in which the variable is defined,
+   *          relative to the scope in which the read is done
+   * @param state to be used to initialize this node
+   * @param source of the read operation
+   * @return a node to read <code>this</code>
+   */
+  default N getThisReadNode(final int contextLevel, final NodeState state,
+      final SourceSection source) {
+    throw new UnsupportedOperationException(
+        "Variable.getThisReadNode not supported on this type of variable: "
+            + getClass().getSimpleName());
+  }
+
+  /**
+   * Create a node to read the special <code>super</code> variable.
+   *
+   * <p>This operation should only be used on variables that are <code>this</code>-like
+   * variables supporting <code>super</code> reads.
+   *
+   * @param contextLevel references the scope in which the variable is defined,
+   *          relative to the scope in which the read is done
+   * @param state to be used to initialize this node
+   * @param source of the read operation
+   * @return a node to read <code>super</code>
+   */
+  default N getSuperReadNode(final int contextLevel, final NodeState state,
+      final SourceSection source) {
+    throw new UnsupportedOperationException(
+        "Variable.getSuperReadNode not supported on this type of variable: "
+            + getClass().getSimpleName());
+  }
+}

--- a/src/bd/inlining/nodes/Inlinable.java
+++ b/src/bd/inlining/nodes/Inlinable.java
@@ -1,0 +1,37 @@
+package bd.inlining.nodes;
+
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.RootNode;
+
+import bd.inlining.Inline;
+import bd.inlining.ScopeBuilder;
+
+
+/**
+ * <code>Inlinable</code> nodes can be replaced, inlined with arbitrary other nodes.
+ *
+ * <p>Note, {@link Inlinable} is different from {@link Inline}. Nodes marked
+ * with @{@link Inline} are replacing more general nodes, which typically have
+ * <code>Inlinable</code> nodes as their children.
+ *
+ * <p>In most cases, the replacement nodes for an <code>Inlinable</code> node will be at least
+ * logically sub-nodes of the inlinable node.
+ *
+ * <p>An example for an <code>Inlinable</code> node is a lambda (closure, block) that
+ * represents for instance the body of a for-each operation. The for-each operation can be
+ * annotated with @{@link Inline}, so that it's children, which include the node representing
+ * the lambda are then inlined. Concretely, the node to replace the <code>Inlinable</code> node
+ * would likely be the {@link RootNode} of the lambda.
+ *
+ * @param <SB> the concrete type of the used {@link ScopeBuilder}
+ */
+public interface Inlinable<SB extends ScopeBuilder<SB>> {
+
+  /**
+   * Inline the give node in the context defined by {@code ScopeBuilder}.
+   *
+   * @param scopeBuilder defines the context for the inlining
+   * @return a new node that represents the inlined behavior
+   */
+  Node inline(SB scopeBuilder);
+}

--- a/src/bd/inlining/nodes/ScopeReference.java
+++ b/src/bd/inlining/nodes/ScopeReference.java
@@ -1,0 +1,35 @@
+package bd.inlining.nodes;
+
+import com.oracle.truffle.api.frame.Frame;
+import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.nodes.Node;
+
+import bd.inlining.ScopeAdaptationVisitor;
+
+
+/**
+ * All {@link Node} classes that potentially reference the scope in some way should implement
+ * the {@link ScopeReference} interface.
+ *
+ * <p>A reference to the scope is typically an access to some type of variable, which might be
+ * realized as an access to a {@link Frame} with a {@link FrameSlot}. More generally, it is any
+ * reference that might need to be adjusted after scopes have been changed. Scope changes can
+ * be cause by inlining, which usually means that some scopes get merged, or because of
+ * splitting, which separates scopes. In either case, nodes with scope references need to be
+ * adapted, which is done with {@link #replaceAfterScopeChange(ScopeAdaptationVisitor)}.
+ */
+public interface ScopeReference {
+
+  /**
+   * Replaces the current node with one that is adapted to match the a changed scope.
+   *
+   * <p>A scope change might have been caused by splitting or inlining. The
+   * {@link ScopeAdaptationVisitor} provides access to the scope information, to obtain updated
+   * scope references, e.g., valid variable or frame slot objects, or for convenience also
+   * complete updated read/write nodes.
+   *
+   * @param visitor the {@link ScopeAdaptationVisitor} that manages the scope adaptation and
+   *          provides access to scope information
+   */
+  void replaceAfterScopeChange(ScopeAdaptationVisitor visitor);
+}

--- a/src/bd/inlining/nodes/WithSource.java
+++ b/src/bd/inlining/nodes/WithSource.java
@@ -1,0 +1,22 @@
+package bd.inlining.nodes;
+
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.SourceSection;
+
+
+/**
+ * All nodes that are handled by inlining are expected to implement {@link WithSource}, which
+ * is used to make sure they have the source section attribution after inlining.
+ */
+public interface WithSource {
+
+  /**
+   * Initialize the node with the source section.
+   *
+   * @param <T> the type of node
+   *
+   * @param source the source section of the node
+   * @return the node itself
+   */
+  <T extends Node> T initialize(SourceSection source);
+}

--- a/src/bd/tools/nodes/Operation.java
+++ b/src/bd/tools/nodes/Operation.java
@@ -8,11 +8,15 @@ public interface Operation {
    * The name or identifier of an operation implemented by a node.
    * An addition node could return for instance <code>"+"</code>. The name should be
    * understandable by humans, and might be shown in a user interface.
+   *
+   * @return name of the operation
    */
   String getOperation();
 
   /**
    * The number of arguments on which the operation depends.
+   *
+   * @return number of required arguments
    */
   int getNumArguments();
 }

--- a/tests/bd/inlining/InliningTests.java
+++ b/tests/bd/inlining/InliningTests.java
@@ -1,0 +1,86 @@
+package bd.inlining;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.api.source.SourceSection;
+
+import bd.basic.ProgramDefinitionError;
+import bd.testsetup.AddNodeFactory;
+import bd.testsetup.ExprNode;
+import bd.testsetup.LambdaNode;
+import bd.testsetup.StringId;
+import bd.testsetup.ValueNode;
+import bd.testsetup.ValueSpecializedNode;
+
+
+public class InliningTests {
+
+  private final SourceSection source =
+      Source.newBuilder("test").name("test").mimeType("x/test").build().createSection(1);
+
+  private final InlinableNodes<String> nodes =
+      new InlinableNodes<String>(new StringId(), Nodes.getInlinableNodes(),
+          Nodes.getInlinableFactories());
+
+  @Test
+  public void testNonInlinableNode() throws ProgramDefinitionError {
+    List<ExprNode> argNodes = new ArrayList<>();
+    argNodes.add(AddNodeFactory.create(null, null));
+    assertNull(nodes.inline("value", argNodes, null, null));
+  }
+
+  @Test
+  public void testValueNode() throws ProgramDefinitionError {
+    List<ExprNode> argNodes = new ArrayList<>();
+    LambdaNode arg = new LambdaNode();
+    argNodes.add(arg);
+    ExprNode valueNode = nodes.inline("value", argNodes, null, source);
+    assertNotNull(valueNode);
+    assertTrue(valueNode instanceof ValueNode);
+
+    ValueNode value = (ValueNode) valueNode;
+
+    assertNotEquals(arg, value.inlined);
+    assertEquals(arg, value.original);
+
+    assertTrue(value.trueVal);
+    assertFalse(value.falseVal);
+
+    assertTrue(valueNode.getSourceSection() == source);
+  }
+
+  @Test
+  public void testValueSpecNode() throws ProgramDefinitionError {
+    List<ExprNode> argNodes = new ArrayList<>();
+    LambdaNode arg = new LambdaNode();
+    argNodes.add(arg);
+    ExprNode valueNode = nodes.inline("valueSpec", argNodes, null, source);
+    assertNotNull(valueNode);
+    assertTrue(valueNode instanceof ValueSpecializedNode);
+
+    ValueSpecializedNode value = (ValueSpecializedNode) valueNode;
+
+    assertNotEquals(arg, value.inlined);
+    assertEquals(arg, value.getLambda());
+    assertTrue(valueNode.getSourceSection() == source);
+  }
+
+  @Test
+  public void testEmptyInit() throws ProgramDefinitionError {
+    InlinableNodes<String> n =
+        new InlinableNodes<>(new StringId(), null, null);
+
+    assertNull(n.inline("nonExisting", null, null, null));
+  }
+}

--- a/tests/bd/inlining/Nodes.java
+++ b/tests/bd/inlining/Nodes.java
@@ -1,0 +1,32 @@
+package bd.inlining;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.oracle.truffle.api.dsl.NodeFactory;
+import com.oracle.truffle.api.nodes.Node;
+
+import bd.testsetup.IfNodeFactory;
+import bd.testsetup.ValueNode;
+import bd.testsetup.ValueSpecializedNodeFactory;
+
+
+class Nodes {
+
+  protected static List<Class<? extends Node>> getInlinableNodes() {
+    List<Class<? extends Node>> nodes = new ArrayList<>();
+
+    nodes.add(ValueNode.class);
+
+    return nodes;
+  }
+
+  protected static List<NodeFactory<? extends Node>> getInlinableFactories() {
+    List<NodeFactory<? extends Node>> factories = new ArrayList<>();
+
+    factories.add(IfNodeFactory.getInstance());
+    factories.add(ValueSpecializedNodeFactory.getInstance());
+
+    return factories;
+  }
+}

--- a/tests/bd/inlining/TScope.java
+++ b/tests/bd/inlining/TScope.java
@@ -1,0 +1,25 @@
+package bd.inlining;
+
+public class TScope implements Scope<TScope, Void> {
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Variable<?>[] getVariables() {
+    return null;
+  }
+
+  @Override
+  public TScope getOuterScopeOrNull() {
+    return null;
+  }
+
+  @Override
+  public TScope getScope(final Void method) {
+    return null;
+  }
+
+  @Override
+  public String getName() {
+    return null;
+  }
+}

--- a/tests/bd/inlining/TScopeBuilder.java
+++ b/tests/bd/inlining/TScopeBuilder.java
@@ -1,0 +1,16 @@
+package bd.inlining;
+
+import com.oracle.truffle.api.source.SourceSection;
+
+import bd.basic.ProgramDefinitionError;
+import bd.inlining.nodes.Inlinable;
+
+
+public class TScopeBuilder implements ScopeBuilder<TScopeBuilder> {
+
+  @Override
+  public Variable<?> introduceTempForInlinedVersion(final Inlinable<TScopeBuilder> node,
+      final SourceSection source) throws ProgramDefinitionError {
+    return null;
+  }
+}

--- a/tests/bd/testsetup/ExprNode.java
+++ b/tests/bd/testsetup/ExprNode.java
@@ -3,9 +3,26 @@ package bd.testsetup;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
+import com.oracle.truffle.api.source.SourceSection;
+
+import bd.inlining.nodes.WithSource;
 
 
-public abstract class ExprNode extends Node {
+public abstract class ExprNode extends Node implements WithSource {
+
+  private SourceSection sourceSection;
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public ExprNode initialize(final SourceSection sourceSection) {
+    this.sourceSection = sourceSection;
+    return this;
+  }
+
+  @Override
+  public SourceSection getSourceSection() {
+    return sourceSection;
+  }
 
   public abstract Object executeGeneric(VirtualFrame frame);
 
@@ -13,6 +30,15 @@ public abstract class ExprNode extends Node {
     Object result = executeGeneric(frame);
     if (result instanceof Integer) {
       return (int) result;
+    } else {
+      throw new UnexpectedResultException(result);
+    }
+  }
+
+  public boolean executeBool(final VirtualFrame frame) throws UnexpectedResultException {
+    Object result = executeGeneric(frame);
+    if (result instanceof Boolean) {
+      return (boolean) result;
     } else {
       throw new UnexpectedResultException(result);
     }

--- a/tests/bd/testsetup/IfNode.java
+++ b/tests/bd/testsetup/IfNode.java
@@ -1,0 +1,21 @@
+package bd.testsetup;
+
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+
+import bd.inlining.Inline;
+
+
+@NodeChild(value = "cond", type = ExprNode.class)
+@NodeChild(value = "thenBranch", type = ExprNode.class)
+@NodeChild(value = "elseBranch", type = ExprNode.class)
+@Inline(selector = "if", inlineableArgIdx = {1, 2})
+@GenerateNodeFactory
+public abstract class IfNode extends ExprNode {
+
+  @Specialization
+  public Object doIf(final boolean cond, final Object thenBranch, final Object elseBranch) {
+    return null;
+  }
+}

--- a/tests/bd/testsetup/LambdaNode.java
+++ b/tests/bd/testsetup/LambdaNode.java
@@ -1,0 +1,20 @@
+package bd.testsetup;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+
+import bd.inlining.TScopeBuilder;
+import bd.inlining.nodes.Inlinable;
+
+
+public final class LambdaNode extends ExprNode implements Inlinable<TScopeBuilder> {
+
+  @Override
+  public Object executeGeneric(final VirtualFrame frame) {
+    return null;
+  }
+
+  @Override
+  public ExprNode inline(final TScopeBuilder scopeBuilder) {
+    return new LambdaNode();
+  }
+}

--- a/tests/bd/testsetup/ValueNode.java
+++ b/tests/bd/testsetup/ValueNode.java
@@ -1,0 +1,32 @@
+package bd.testsetup;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.frame.VirtualFrame;
+
+import bd.inlining.Inline;
+import bd.inlining.Inline.False;
+import bd.inlining.Inline.True;
+
+
+@NodeChild(value = "lambda", type = ExprNode.class)
+@Inline(selector = "value", inlineableArgIdx = {0}, additionalArgs = {True.class, False.class})
+public final class ValueNode extends ExprNode {
+
+  public final LambdaNode original; // not a child
+  public final LambdaNode inlined;  // not a child
+  public final boolean    trueVal;
+  public final boolean    falseVal;
+
+  public ValueNode(final LambdaNode original, final LambdaNode inlined, final boolean arg1,
+      final boolean arg2) {
+    this.original = original;
+    this.inlined = inlined;
+    this.trueVal = arg1;
+    this.falseVal = arg2;
+  }
+
+  @Override
+  public Object executeGeneric(final VirtualFrame frame) {
+    return null;
+  }
+}

--- a/tests/bd/testsetup/ValueSpecializedNode.java
+++ b/tests/bd/testsetup/ValueSpecializedNode.java
@@ -1,0 +1,27 @@
+package bd.testsetup;
+
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+
+import bd.inlining.Inline;
+
+
+@NodeChild(value = "lambda", type = ExprNode.class)
+@Inline(selector = "valueSpec", inlineableArgIdx = {0})
+@GenerateNodeFactory
+public abstract class ValueSpecializedNode extends ExprNode {
+
+  public final LambdaNode inlined;
+
+  public ValueSpecializedNode(final LambdaNode inlined) {
+    this.inlined = inlined;
+  }
+
+  public abstract ExprNode getLambda();
+
+  @Specialization
+  public int doInt(final int lambda) {
+    return 42;
+  }
+}


### PR DESCRIPTION
The `inlining` diamond provides infrastructure to support inlining at parse time and splitting at execution time. Inlining enables us to optimize more complex structures such as loops, iteration, selection, or other elements that often take lambdas, closures, or other kind of anonymous methods. If they are provided lexically, and are trivially non-accessible by language constructs, it can be very beneficial to inline them on the AST level already to optimize execution time in the interpreter, which can also reduce compilation time.

This infrastructure provides the basic mechanisms that a language independent. This includes a general visitor that can adapt lexical scopes for instance also after simple splitting, which can be necessary, for instance to ensure that the split methods are independent and specialize independently at run time.

Cleanup changes have been moved to #7.

The corresponding PRs for TruffleSOM and SOMns are:
- https://github.com/SOM-st/TruffleSOM/pull/13
- https://github.com/smarr/SOMns/pull/231