### PR TITLE
Update Eclipse formatter and use minimized tar ball

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 install:
   - |
       export ECLIPSE_TAR=eclipse.tar.gz
-      export ECLIPSE_URL=http://archive.eclipse.org/eclipse/downloads/drops4/R-4.6.3-201703010400/eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz
+      export ECLIPSE_URL=http://stefan-marr.de/downloads/eclipse-4.7.2-x86-64.tar.gz
       wget ${ECLIPSE_URL} -O ${ECLIPSE_TAR}
       tar -C ${TRAVIS_BUILD_DIR}/.. -xzf ${ECLIPSE_TAR}
       export ECLIPSE_EXE=${TRAVIS_BUILD_DIR}/../eclipse/eclipse


### PR DESCRIPTION
The main reason for this change is that archive.eclipse.org is terribly slow, and it always bothered me that the archive is huge.

The self-hosted version is now about 70MB instead of >200MB.

The partially automated script is at https://gist.github.com/smarr/6803aa169879d18b4779041bac8d9e32