### PR TITLE
Weaken assertion to allow additional elements in calling convention

### DIFF
--- a/.checkstyle_checks.xml
+++ b/.checkstyle_checks.xml
@@ -12,7 +12,6 @@
   <property name="severity" value="error"/>
   <module name="TreeWalker">
     <property name="tabWidth" value="4"/>
-    <module name="FileContentsHolder"/>
     <module name="JavadocStyle">
       <property name="checkHtml" value="false"/>
     </module>
@@ -137,13 +136,23 @@
       <property name="format" value=" ,"/>
       <property name="message" value="illegal space before a comma"/>
       <property name="ignoreComments" value="true"/>
-      <metadata name="com.atlassw.tools.eclipse.checkstyle.customMessage" value="Illegal whitespace before a comma."/>
       <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Checks for whitespace before a comma."/>
+      <metadata name="com.atlassw.tools.eclipse.checkstyle.customMessage" value="Illegal whitespace before a comma."/>
     </module>
     <module name="RegexpSinglelineJava">
       <metadata name="net.sf.eclipsecs.core.comment" value="needs a space after comment start"/>
       <property name="format" value="[^:&quot;]//[^&quot;\s]"/>
       <property name="message" value="needs a space after comment start"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="id" value="sysout"/>
+      <property name="format" value="System\.(out|err)\.print"/>
+      <property name="message" value="System\.(out|err)\.print should be avoided. Use a logging method instead."/>
+    </module>
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="Checkstyle: stop"/>
+      <property name="onCommentFormat" value="Checkstyle: resume"/>
+      <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable all checks"/>
     </module>
   </module>
   <module name="SuppressionFilter">
@@ -161,79 +170,10 @@
   <module name="NewlineAtEndOfFile">
     <property name="lineSeparator" value="lf"/>
   </module>
-  <module name="Translation"/>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="Checkstyle: stop constant name check"/>
-    <property name="onCommentFormat" value="Checkstyle: resume constant name check"/>
-    <property name="checkFormat" value="ConstantNameCheck"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Allow non-conforming constant names"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="Checkstyle: stop method name check"/>
-    <property name="onCommentFormat" value="Checkstyle: resume method name check"/>
-    <property name="checkFormat" value="MethodName"/>
-    <property name="checkC" value="false"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable method name checks"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CheckStyle: stop parameter assignment check"/>
-    <property name="onCommentFormat" value="CheckStyle: resume parameter assignment check"/>
-    <property name="checkFormat" value="ParameterAssignment"/>
-    <property name="checkC" value="false"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable Parameter Assignment"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="Checkstyle: stop final variable check"/>
-    <property name="onCommentFormat" value="Checkstyle: resume final variable check"/>
-    <property name="checkFormat" value="FinalLocalVariable"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable final variable checks"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="Checkstyle: stop"/>
-    <property name="onCommentFormat" value="Checkstyle: resume"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable all checks"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="// START GENERATED RAW ASSEMBLER METHODS"/>
-    <property name="onCommentFormat" value="// END GENERATED RAW ASSEMBLER METHODS"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable all checks for generated raw assembler methods"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="// START GENERATED LABEL ASSEMBLER METHODS"/>
-    <property name="onCommentFormat" value="// END GENERATED LABEL ASSEMBLER METHODS"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable all checks for generated label assembler methods"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CheckStyle: stop inner assignment check"/>
-    <property name="onCommentFormat" value="CheckStyle: resume inner assignment check"/>
-    <property name="checkFormat" value="InnerAssignment"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable inner assignment checks"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="Checkstyle: stop field name check"/>
-    <property name="onCommentFormat" value="Checkstyle: resume field name check"/>
-    <property name="checkFormat" value="MemberName"/>
-    <property name="checkC" value="false"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable field name checks"/>
-  </module>
   <module name="RegexpMultiline">
     <metadata name="net.sf.eclipsecs.core.comment" value="illegal Windows line ending"/>
     <property name="format" value="\r\n"/>
     <property name="message" value="illegal Windows line ending"/>
   </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CheckStyle: stop system..print check"/>
-    <property name="onCommentFormat" value="CheckStyle: resume system..print check"/>
-    <property name="checkFormat" value="RegexpSingleline"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable System.(out|err).print checks"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CheckStyle: stop header check"/>
-    <property name="onCommentFormat" value="CheckStyle: resume header check"/>
-    <property name="checkFormat" value=".*Header"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable header checks"/>
-  </module>
-  <module name="RegexpSingleline">
-    <property name="format" value="System\.(out|err)\.print"/>
-  </module>
+  <module name="Translation"/>
 </module>

--- a/build.xml
+++ b/build.xml
@@ -11,7 +11,7 @@
     <property name="junit.version" value="4.12" />
     <property name="jacoco.version" value="0.8.0" />
 
-    <property name="checkstyle.version" value="7.8.2" />
+    <property name="checkstyle.version" value="8.11" />
     <property name="mvn.url" value="https://repo1.maven.org/maven2" />
 
     <property environment="env"/>
@@ -121,7 +121,7 @@
     
     <target name="checkstyle-jar">
         <mkdir dir="${lib.dir}" />
-        <get src="http://tenet.dl.sourceforge.net/project/checkstyle/checkstyle/${checkstyle.version}/checkstyle-${checkstyle.version}-all.jar"
+        <get src="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${checkstyle.version}/checkstyle-${checkstyle.version}-all.jar"
             usetimestamp="true"
             dest="${lib.dir}/checkstyle-${checkstyle.version}-all.jar" />
     </target>

--- a/src/bd/primitives/Specializer.java
+++ b/src/bd/primitives/Specializer.java
@@ -102,7 +102,7 @@ public class Specializer<Context, ExprT, Id> {
   @SuppressWarnings("unchecked")
   public ExprT create(final Object[] arguments, final ExprT[] argNodes,
       final SourceSection section, final boolean eagerWrapper) {
-    assert arguments == null || arguments.length == argNodes.length;
+    assert arguments == null || arguments.length >= argNodes.length;
     int numArgs = numberOfNodeConstructorArguments(argNodes);
 
     Object[] ctorArgs = new Object[numArgs];


### PR DESCRIPTION
Fixed assertion to make ShadowStack entries work in SOMns.

[smarr edit]: this weakens the assertion in the specializer to allow for additional elements in the calling convention, which do not need to be represented by nodes.