### PR TITLE
Update Truffle to >1.0.0-rc5

### DIFF
--- a/.factorypath
+++ b/.factorypath
@@ -1,4 +1,6 @@
 <factorypath>
-    <factorypathentry kind="WKSPJAR" id="/TRUFFLE_DSL_PROCESSOR/truffle-dsl-processor.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="WKSPJAR" id="/TRUFFLE_API/truffle-api.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="WKSPJAR" id="/TRUFFLE_DSL_PROCESSOR/truffle-dsl-processor.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="WKSPJAR" id="/TRUFFLE_DSL_PROCESSOR_INTERNAL/truffle-dsl-processor-internal.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="WKSPJAR" id="/TRUFFLE_DSL_PROCESSOR_INTEROP_INTERNAL/truffle-dsl-processor-interop-internal.jar" enabled="true" runInBatchMode="false"/>
 </factorypath>

--- a/.graal-git-repo
+++ b/.graal-git-repo
@@ -15,8 +15,8 @@ GRAAL_REPO_URL = "https://github.com/smarr/truffle.git"
 MX_REPO_URL    = "https://github.com/graalvm/mx.git"
 
 # And these are the repo revisions we test against
-GRAAL_REPO_REV = "3ed852dd7266e1423e848b64673f906da2e70ed7"
-MX_REPO_REV    = "41038233e53f5d47a857ee73a2227ff4de9ad1c3"
+GRAAL_REPO_REV = "a9fba6a775ffc60a90959d2eff4e66d15e9867a9"
+MX_REPO_REV    = "5bc7f83b9d66a31259b90933fcd0aa64d38b8d1e"
 
 
 def update(lines, var, val):

--- a/build.xml
+++ b/build.xml
@@ -17,7 +17,8 @@
     <property name="jacoco.version" value="0.8.0" />
 
     <property name="checkstyle.version" value="8.11" />
-    <property name="mvn.url" value="https://repo1.maven.org/maven2" />
+    <property name="mvn.url"           value="https://maven-central.storage.googleapis.com/repos/central/data" />  <!-- https://repo1.maven.org/maven2 gives 403 on Travis CI -->
+    
 
     <property environment="env"/>
 

--- a/src/bd/basic/nodes/DummyParent.java
+++ b/src/bd/basic/nodes/DummyParent.java
@@ -13,4 +13,8 @@ public final class DummyParent extends Node {
   public DummyParent(final Node node) {
     this.child = insert(node);
   }
+
+  public void notifyInserted() {
+    super.notifyInserted(child);
+  }
 }

--- a/src/bd/basic/nodes/DummyParent.java
+++ b/src/bd/basic/nodes/DummyParent.java
@@ -1,20 +1,30 @@
 package bd.basic.nodes;
 
+import com.oracle.truffle.api.TruffleLanguage;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.RootNode;
 
 
 /**
  * Dummy Node to work around Truffle's restriction that a node, which is going to
  * be instrumented, needs to have a parent.
  */
-public final class DummyParent extends Node {
+public final class DummyParent extends RootNode {
   @Child public Node child;
 
-  public DummyParent(final Node node) {
+  public DummyParent(final TruffleLanguage<?> language, final Node node) {
+    super(language);
     this.child = insert(node);
   }
 
   public void notifyInserted() {
     super.notifyInserted(child);
+  }
+
+  @Override
+  public Object execute(final VirtualFrame frame) {
+    throw new UnsupportedOperationException(
+        "This is a dummy node, and should not be executed");
   }
 }

--- a/src/bd/inlining/NodeVisitorUtil.java
+++ b/src/bd/inlining/NodeVisitorUtil.java
@@ -1,5 +1,6 @@
 package bd.inlining;
 
+import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeVisitor;
 
@@ -10,8 +11,8 @@ final class NodeVisitorUtil {
 
   @SuppressWarnings("unchecked")
   public static <ExprT extends Node> ExprT applyVisitor(final ExprT body,
-      final NodeVisitor visitor) {
-    DummyParent dummyParent = new DummyParent(body);
+      final NodeVisitor visitor, final TruffleLanguage<?> language) {
+    DummyParent dummyParent = new DummyParent(language, body);
 
     body.accept(visitor);
 

--- a/src/bd/inlining/ScopeAdaptationVisitor.java
+++ b/src/bd/inlining/ScopeAdaptationVisitor.java
@@ -1,5 +1,6 @@
 package bd.inlining;
 
+import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeUtil;
 import com.oracle.truffle.api.nodes.NodeVisitor;
@@ -36,11 +37,12 @@ public final class ScopeAdaptationVisitor implements NodeVisitor {
    * @return a copy of {@code body} adapted to the given scope
    */
   public static <N extends Node> N adapt(final N body, final Scope<?, ?> newScope,
-      final int appliesTo, final boolean someOuterScopeIsMerged) {
+      final int appliesTo, final boolean someOuterScopeIsMerged,
+      final TruffleLanguage<?> language) {
     N inlinedBody = NodeUtil.cloneNode(body);
 
     return NodeVisitorUtil.applyVisitor(inlinedBody,
-        new ScopeAdaptationVisitor(newScope, appliesTo, someOuterScopeIsMerged));
+        new ScopeAdaptationVisitor(newScope, appliesTo, someOuterScopeIsMerged), language);
   }
 
   private ScopeAdaptationVisitor(final Scope<?, ?> scope, final int appliesTo,

--- a/src/bd/primitives/Specializer.java
+++ b/src/bd/primitives/Specializer.java
@@ -5,6 +5,7 @@ import java.lang.reflect.InvocationTargetException;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.source.SourceSection;
 
+import bd.inlining.nodes.WithSource;
 import bd.primitives.Primitive.NoChild;
 import bd.primitives.nodes.EagerlySpecializable;
 import bd.primitives.nodes.WithContext;
@@ -120,7 +121,11 @@ public class Specializer<Context, ExprT, Id> {
     }
 
     if (extraChildFactory != null) {
-      ctorArgs[offset] = extraChildFactory.createNode(new Object[extraArity]);
+      Object extraNode = extraChildFactory.createNode(new Object[extraArity]);
+      if (extraNode instanceof WithSource) {
+        ((WithSource) extraNode).initialize(section);
+      }
+      ctorArgs[offset] = extraNode;
       offset += 1;
     }
 

--- a/src/bd/primitives/nodes/PreevaluatedExpression.java
+++ b/src/bd/primitives/nodes/PreevaluatedExpression.java
@@ -1,6 +1,7 @@
 package bd.primitives.nodes;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.NodeInterface;
 
 
 /**
@@ -12,7 +13,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
  * afterwards, a new specialization node is determined that then needs to be able to accept the
  * arguments.
  */
-public interface PreevaluatedExpression {
+public interface PreevaluatedExpression extends NodeInterface {
 
   /**
    * Execute the node with the given arguments.

--- a/tests/bd/inlining/InliningTests.java
+++ b/tests/bd/inlining/InliningTests.java
@@ -27,7 +27,7 @@ import bd.testsetup.ValueSpecializedNode;
 public class InliningTests {
 
   private final SourceSection source =
-      Source.newBuilder("test").name("test").mimeType("x/test").build().createSection(1);
+      Source.newBuilder("x", "test", "test").mimeType("x/test").build().createSection(1);
 
   private final InlinableNodes<String> nodes =
       new InlinableNodes<String>(new StringId(), Nodes.getInlinableNodes(),


### PR DESCRIPTION
This PR introduces changes to better support Truffle >1.0.0-rc5.

We update to the latest version, which is some 1.0.0-rc6-dev version.

The main changes are:
- mark `PreevaluatedExpression` as `NodeInterface`, Truffle is now more strict about it
- make `DummyParent` a full `RootNode`, because Truffle now searches for the `RootNode`, for instance when instrumenting nodes
- use a Maven mirror that doesn't have spurious 403 failures

I requested a review, just so that you are informed of what's going on.
Will merge right away, but am happy to fix things up afterwards.