### PR TITLE
Enable primitive support without reflection after initialization time

### DIFF
--- a/src/bd/primitives/PrimitiveLoader.java
+++ b/src/bd/primitives/PrimitiveLoader.java
@@ -21,7 +21,6 @@ import bd.basic.IdProvider;
 public abstract class PrimitiveLoader<Context, ExprT, Id> {
 
   private final IdProvider<Id> ids;
-  protected final Context      context;
 
   /** Primitives for selector. */
   private final HashMap<Id, Specializer<Context, ExprT, Id>> eagerPrimitives;
@@ -31,9 +30,8 @@ public abstract class PrimitiveLoader<Context, ExprT, Id> {
    *
    * @param context the object representing the language's context
    */
-  protected PrimitiveLoader(final IdProvider<Id> ids, final Context context) {
+  protected PrimitiveLoader(final IdProvider<Id> ids) {
     this.ids = ids;
-    this.context = context;
     this.eagerPrimitives = new HashMap<>();
   }
 
@@ -119,23 +117,12 @@ public abstract class PrimitiveLoader<Context, ExprT, Id> {
   private <T> Specializer<Context, ExprT, Id> createSpecializer(final Primitive prim,
       final NodeFactory<? extends ExprT> factory) {
     try {
-      // Try with erased type signature
       return prim.specializer()
-                 .getConstructor(Primitive.class, NodeFactory.class, Object.class)
-                 .newInstance(prim, factory, context);
+                 .getConstructor(Primitive.class, NodeFactory.class)
+                 .newInstance(prim, factory);
     } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
-        | InvocationTargetException | SecurityException e) {
+        | InvocationTargetException | NoSuchMethodException | SecurityException e) {
       throw new RuntimeException(e);
-    } catch (NoSuchMethodException e) {
-      try {
-        // Try with concrete type signature
-        return prim.specializer()
-                   .getConstructor(Primitive.class, NodeFactory.class, context.getClass())
-                   .newInstance(prim, factory, context);
-      } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
-          | InvocationTargetException | NoSuchMethodException | SecurityException e1) {
-        throw new RuntimeException(e);
-      }
     }
   }
 

--- a/src/bd/primitives/Specializer.java
+++ b/src/bd/primitives/Specializer.java
@@ -54,6 +54,10 @@ public class Specializer<Context, ExprT, Id> {
     }
   }
 
+  public Primitive getPrimitive() {
+    return prim;
+  }
+
   public boolean inParser() {
     return prim.inParser() && !prim.requiresArguments();
   }

--- a/src/bd/primitives/Specializer.java
+++ b/src/bd/primitives/Specializer.java
@@ -22,20 +22,18 @@ import bd.settings.VmSettings;
  *          of interned string construct
  */
 public class Specializer<Context, ExprT, Id> {
-  protected final Context                    context;
-  protected final Primitive                  prim;
-  protected final NodeFactory<ExprT>         fact;
+  protected final Primitive          prim;
+  protected final NodeFactory<ExprT> fact;
+
   private final NodeFactory<? extends ExprT> extraChildFactory;
 
   private final int     extraArity;
   private final boolean requiresContext;
 
   @SuppressWarnings("unchecked")
-  public Specializer(final Primitive prim, final NodeFactory<ExprT> fact,
-      final Context context) {
+  public Specializer(final Primitive prim, final NodeFactory<ExprT> fact) {
     this.prim = prim;
     this.fact = fact;
-    this.context = context;
 
     this.requiresContext = WithContext.class.isAssignableFrom(fact.getNodeClass());
 
@@ -102,7 +100,7 @@ public class Specializer<Context, ExprT, Id> {
 
   @SuppressWarnings("unchecked")
   public ExprT create(final Object[] arguments, final ExprT[] argNodes,
-      final SourceSection section, final boolean eagerWrapper) {
+      final SourceSection section, final boolean eagerWrapper, final Context context) {
     assert arguments == null || arguments.length >= argNodes.length;
     int numArgs = numberOfNodeConstructorArguments(argNodes);
 

--- a/tests/bd/primitives/PrimitiveTests.java
+++ b/tests/bd/primitives/PrimitiveTests.java
@@ -21,7 +21,7 @@ import bd.testsetup.LangContext;
 
 public class PrimitiveTests {
 
-  private final Primitives ps = new Primitives(new LangContext());
+  private final Primitives ps = new Primitives();
 
   @Test
   public void testPrimitiveAnnotation() {

--- a/tests/bd/primitives/PrimitiveTests.java
+++ b/tests/bd/primitives/PrimitiveTests.java
@@ -80,7 +80,7 @@ public class PrimitiveTests {
   @Test
   public void testExtraChild() {
     Specializer<LangContext, ExprNode, String> s = ps.getParserSpecializer("addAbs", null);
-    ExprNode n = s.create(null, new ExprNode[1], null, true);
+    ExprNode n = s.create(null, new ExprNode[1], null, true, null);
     assertTrue(n instanceof AddAbsNode);
 
     // Note: this is fragile, because it depends on the TruffleDSL node implementation strategy

--- a/tests/bd/primitives/Primitives.java
+++ b/tests/bd/primitives/Primitives.java
@@ -3,8 +3,6 @@ package bd.primitives;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.oracle.truffle.api.dsl.NodeFactory;
-
 import bd.testsetup.AbsNodeFactory;
 import bd.testsetup.AddAbsNodeFactory;
 import bd.testsetup.AddNodeFactory;
@@ -21,19 +19,19 @@ public class Primitives extends PrimitiveLoader<LangContext, ExprNode, String> {
   }
 
   @Override
-  protected List<NodeFactory<? extends ExprNode>> getFactories() {
-    List<NodeFactory<? extends ExprNode>> allFactories = new ArrayList<>();
+  protected List<Specializer<LangContext, ExprNode, String>> getSpecializers() {
+    List<Specializer<LangContext, ExprNode, String>> allSpecializers = new ArrayList<>();
 
-    allFactories.add(AddNodeFactory.getInstance());
-    allFactories.add(AddWithSpecializerNodeFactory.getInstance());
-    allFactories.add(AbsNodeFactory.getInstance());
-    allFactories.add(AddAbsNodeFactory.getInstance());
+    add(allSpecializers, AddNodeFactory.getInstance());
+    add(allSpecializers, AddWithSpecializerNodeFactory.getInstance());
+    add(allSpecializers, AbsNodeFactory.getInstance());
+    add(allSpecializers, AddAbsNodeFactory.getInstance());
 
-    return allFactories;
+    return allSpecializers;
   }
 
   @Override
-  protected void registerPrimitive(final Primitive prim,
+  protected void registerPrimitive(
       final Specializer<LangContext, ExprNode, String> specializer) {
     /* not needed for testing */
   }

--- a/tests/bd/primitives/Primitives.java
+++ b/tests/bd/primitives/Primitives.java
@@ -15,8 +15,8 @@ import bd.testsetup.StringId;
 
 
 public class Primitives extends PrimitiveLoader<LangContext, ExprNode, String> {
-  protected Primitives(final LangContext context) {
-    super(new StringId(), context);
+  protected Primitives() {
+    super(new StringId());
     initialize();
   }
 

--- a/tests/bd/testsetup/AddWithSpecializerNode.java
+++ b/tests/bd/testsetup/AddWithSpecializerNode.java
@@ -18,9 +18,8 @@ import bd.testsetup.AddWithSpecializerNode.AlwaysSpecialize;
 public abstract class AddWithSpecializerNode extends ExprNode {
 
   public static class AlwaysSpecialize extends Specializer<LangContext, ExprNode, String> {
-    public AlwaysSpecialize(final Primitive prim, final NodeFactory<ExprNode> fact,
-        final LangContext ctx) {
-      super(prim, fact, ctx);
+    public AlwaysSpecialize(final Primitive prim, final NodeFactory<ExprNode> fact) {
+      super(prim, fact);
     }
 
     @Override


### PR DESCRIPTION
This changes the primitives support to avoid using reflection after initialization time.

With this change, the structure/signatures of this BlackDiamond ensures that for instance on SubstrateVM, we can keep the `Specializer` objects in the generated image, and do not need reflection to instantiate them at run time.

As it turns out, the `PrimitiveLoader` does not seem to need access to a `Context`.
Instead, it can passed in directly when a specializer instantiates a node.

This further avoids type issues with erased signatures for the `Context`, because it is a generic type.