### PR TITLE
Make PrimitiveLoader.ids protected

### DIFF
--- a/src/bd/primitives/PrimitiveLoader.java
+++ b/src/bd/primitives/PrimitiveLoader.java
@@ -20,7 +20,7 @@ import bd.basic.IdProvider;
  */
 public abstract class PrimitiveLoader<Context, ExprT, Id> {
 
-  private final IdProvider<Id> ids;
+  protected final IdProvider<Id> ids;
 
   /** Primitives for selector. */
   private final HashMap<Id, Specializer<Context, ExprT, Id>> eagerPrimitives;


### PR DESCRIPTION
This makes ids accessible from subclasses, which seems like a fairly unproblematic change.

This change is useful for https://github.com/SOM-st/TruffleSOM/pull/25