### PR TITLE
Add basic support for long-based encoding of source coordinates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       
       - name: Tests
         run: |
-          export JAVA_HOME=$JAVA_HOME_8_X64
+          export JAVA_HOME=$JAVA_HOME_17_X64
           ant -e test
 
       - name: CheckStyle
@@ -23,7 +23,7 @@ jobs:
       - name: Download Eclipse
         run: |
           export ECLIPSE_TAR=eclipse.tar.gz
-          export ECLIPSE_URL=https://ftp.snt.utwente.nl/pub/software/eclipse/eclipse/downloads/drops4/R-4.19-202103031800/eclipse-SDK-4.19-linux-gtk-x86_64.tar.gz
+          export ECLIPSE_URL=https://ftp.snt.utwente.nl/pub/software/eclipse/eclipse/downloads/drops4/R-4.23-202203080310/eclipse-SDK-4.23-linux-gtk-x86_64.tar.gz
           curl ${ECLIPSE_URL} -o ${ECLIPSE_TAR}
           tar -C ${GITHUB_WORKSPACE}/.. -xzf ${ECLIPSE_TAR}
 

--- a/.graal-git-repo
+++ b/.graal-git-repo
@@ -11,12 +11,12 @@ import sys
 import os
 
 # We use the following repositories
-GRAAL_REPO_URL = "https://github.com/smarr/truffle.git"
+GRAAL_REPO_URL = "https://github.com/oracle/graal.git"
 MX_REPO_URL    = "https://github.com/graalvm/mx.git"
 
 # And these are the repo revisions we test against
-GRAAL_REPO_REV = "60bdbbd657e21d98fa0e6141fe3f4a786010b9e8"
-MX_REPO_REV    = "7ffcabe734973b89f0211da3a174ac2d298c78bc"
+GRAAL_REPO_REV = "91b68c2bcb9a0f41c0f437b6d7adf736786f36b6"
+MX_REPO_REV    = "65c6727a0080515696c25934f3da02ef7a1aa43a"
 
 
 def update(lines, var, val):

--- a/build.xml
+++ b/build.xml
@@ -1,18 +1,15 @@
 <project name="black-diamonds" basedir="." default="compile"
     xmlns:if="ant:if"
     xmlns:jacoco="antlib:org.jacoco.ant">
-    
-    <property name="force.java8" value="false" />  <!-- the default value,
-       can be changed by simply setting the property when calling ant -->
 
     <property name="src.dir"     location="src"/>
     <property name="src_gen.dir" location="src_gen"/>
     <property name="test.dir"    value="tests"/>
     <property name="lib.dir"     value="libs"/>
     <property name="sdk.dir"     value="graal/sdk" />
-    <property name="sdk.build"   value="${sdk.dir}/mxbuild/dists/jdk1.8" />
+    <property name="sdk.build"   value="${sdk.dir}/mxbuild/dists" />
     <property name="truffle.dir" value="graal/truffle" />
-    <property name="truffle.build" value="${truffle.dir}/mxbuild/dists/jdk1.8" />
+    <property name="truffle.build" value="${truffle.dir}/mxbuild/dists" />
     <property name="junit.version" value="4.12" />
     <property name="jacoco.version" value="0.8.0" />
 
@@ -159,17 +156,14 @@
           <compilerarg line="-s ${src_gen.dir}" />
           <compilerarg line="-XDignore.symbol.file" />
           <compilerarg line="-Xlint:all" />
-          <compilerarg line="--release 8" if:true="${force.java8}" />
         </javac>
         <javac includeantruntime="false" srcdir="${src_gen.dir}" destdir="${classes.dir}" debug="true">
           <classpath refid="project.classpath" />
           <compilerarg line="-s ${src_gen.dir}" />
           <compilerarg line="-Xlint:all" />
-          <compilerarg line="--release 8" if:true="${force.java8}" />
         </javac>
         <javac includeantruntime="false" srcdir="${test.dir}" destdir="${classes.dir}" debug="true">
           <classpath refid="project.classpath" />
-          <compilerarg line="--release 8" if:true="${force.java8}" />
         </javac>
     </target>
     

--- a/src/bd/source/SourceCoordinate.java
+++ b/src/bd/source/SourceCoordinate.java
@@ -16,6 +16,10 @@ import com.oracle.truffle.api.source.SourceSection;
  * <p>
  * The {@code charIndex} may not be set. It can be derived from startLine and startColumn,
  * if the source file is present.
+ *
+ * <p>
+ * In addition to an object representation, a {@code long}-based representation,
+ * is supported, too.
  */
 public class SourceCoordinate {
   public final int           startLine;
@@ -109,5 +113,36 @@ public class SourceCoordinate {
 
   public static String getURI(final Source source) {
     return source.getURI().toString();
+  }
+
+  public static long createEmptyCoordinate() {
+    // start at column 1, index 1
+    return 0x1L;
+  }
+
+  public static long createCoordinate(final SourceSection section) {
+    return create(section.getCharIndex(), section.getCharLength());
+  }
+
+  public static long create(final int startIndex, final int length) {
+    return (((long) length) << 32) | (startIndex & 0xFFFFFFFFL);
+  }
+
+  public static long withZeroLength(final long coord) {
+    return coord & 0xFFFFFFFFL;
+  }
+
+  public static int getStartIndex(final long coord) {
+    return (int) (coord & 0xFFFFFFFFL);
+  }
+
+  public static int getLength(final long coord) {
+    return (int) ((coord >>> 32) & 0xFFFFFFFFL);
+  }
+
+  public static SourceSection createSourceSection(final Source source, final long coord) {
+    int startIndex = getStartIndex(coord);
+    int length = getLength(coord);
+    return source.createSection(startIndex, length);
   }
 }


### PR DESCRIPTION
For the moment, this is the minimal set of methods for compatibility with TruffleSOM.

The idea is to use a `long` instead of an object, to encode the source section details, which reduces the overall AST footprint.

This also updates Graal, Eclipse, and JDK in CI.