### PR TITLE
Add SourceCoordinate.getLocationQualifier(int startIndex, Source source)

### DIFF
--- a/src/bd/source/SourceCoordinate.java
+++ b/src/bd/source/SourceCoordinate.java
@@ -111,6 +111,12 @@ public class SourceCoordinate {
     return ":" + section.getStartLine() + ":" + section.getStartColumn();
   }
 
+  public static String getLocationQualifier(final int startIndex, final Source source) {
+    int lineNumber = source.getLineNumber(startIndex);
+    int column = source.getColumnNumber(startIndex);
+    return ":" + lineNumber + ":" + column;
+  }
+
   public static String getURI(final Source source) {
     return source.getURI().toString();
   }


### PR DESCRIPTION
This is a helper method, useful for use when a parser uses just a start index instead of a SourceCoordinate or SourceSection object.